### PR TITLE
feat(delta): export DeltaOrderStatusMap for public consumption

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.3.0",
+  "version": "10.3.1",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -537,3 +537,6 @@ export * from './methods/otcOrders/helpers/types';
 
 // helpers for Delta Orders
 export { OrderHelpers } from './methods/delta/helpers/orders';
+
+// runtime value backing the DeltaOrderStatus type
+export { DeltaOrderStatusMap } from './methods/delta/types';

--- a/src/methods/delta/types.ts
+++ b/src/methods/delta/types.ts
@@ -127,7 +127,7 @@ export type BridgeRoute = {
 /* ------------------------------------------------------------------ */
 
 /** @description Integrator-facing order status returned by v2 order endpoints. */
-const DeltaOrderStatusMap = {
+export const DeltaOrderStatusMap = {
   Pending: 'PENDING',
   AwaitingSignature: 'AWAITING_SIGNATURE',
   Active: 'ACTIVE',


### PR DESCRIPTION
`DeltaOrderStatus` is already exported from `src/methods/delta/types.ts`, but the underlying `DeltaOrderStatusMap` const is not. This means consumers can type against the status union, but cannot reference the concrete status string values at runtime — e.g. `if (order.status === DeltaOrderStatusMap.Completed)` — and instead have to hardcode magic strings like `'COMPLETED'`.

This one-line change exports the const alongside the type so integrators can use the named values directly.

No behavior change; purely additive to the public API.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public API export with no runtime behavior changes.
> 
> **Overview**
> **Exports the runtime status map** so integrators can compare order statuses without hardcoding API strings.
> 
> `DeltaOrderStatus` was already public, but `DeltaOrderStatusMap` stayed internal. The const is now exported from `delta/types` and re-exported from the package entrypoint, enabling checks like `order.status === DeltaOrderStatusMap.Completed` instead of `'COMPLETED'`.
> 
> Version is bumped to **10.3.1** for the patch release.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 30dd59c960bdc0a924a4edfcb85a7c6508755330. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->