### PR TITLE
Chore/add type DeltaAuctionBase.transactions|refunds.timestamp

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@velora-dex/sdk",
-  "version": "10.3.1",
+  "version": "10.4.0",
   "main": "dist/index.js",
   "module": "dist/sdk.esm.js",
   "typings": "dist/index.d.ts",

--- a/src/methods/delta/types.ts
+++ b/src/methods/delta/types.ts
@@ -188,6 +188,8 @@ export type DeltaTransaction = {
   filledPercent: number;
   spentAmount: string | null;
   receivedAmount: string | null;
+  /** @description ISO datetime string. */
+  timestamp: string | null;
 };
 
 export type BridgeRefundMetadata = {
@@ -195,6 +197,8 @@ export type BridgeRefundMetadata = {
   chainId: number;
   token: Address;
   amount: string;
+  /** @description ISO datetime string. */
+  timestamp: string | null;
 };
 
 type DeltaAuctionBase = {


### PR DESCRIPTION
`DeltaAuctionBase.transactions|refunds.timestamp` with transaction's timestamp

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, nullable TypeScript fields only; consumers remain compatible and no auth or execution paths change.
> 
> **Overview**
> Bumps `@velora-dex/sdk` to **10.4.0** and extends Delta v2 order typings so per-entry timing can be surfaced from the API.
> 
> **`DeltaTransaction`** and **`BridgeRefundMetadata`** each gain an optional **`timestamp: string | null`**, documented as an ISO datetime. These fields sit on the transaction/refund arrays already carried by **`DeltaAuction`** (via **`DeltaAuctionBase`**); no SDK runtime or helper logic changes appear in this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d88ed0c494d6e2482cabd81ff02e7199c6c1097d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->